### PR TITLE
Battery percentage rounding on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ export function activate(context: ExtensionContext) {
             return Promise.reject(new Error('No battery could be found'));
         }
         stdout = parseFloat(stdout.trim().split('\n')[1]);
-        return toDecimal(stdout > 100 ? 100 : stdout) * 100
+        return Math.round(toDecimal(stdout > 100 ? 100 : stdout) * 100)
     })
 
     let batteryLevelStateChecker


### PR DESCRIPTION
On Windows, the battery percentage is sometimes shown as not-rounded Decimal, e.g. 59,999999998%